### PR TITLE
subtle change to the intent of the OID

### DIFF
--- a/draft-davidben-x509-alg-none.md
+++ b/draft-davidben-x509-alg-none.md
@@ -40,7 +40,7 @@ informative:
 --- abstract
 
 This document defines a placeholder X.509 signature algorithm that may be used
-in contexts where the consumer of the certificate does not intend to verify the
+in contexts where the consumer of the certificate is not expected to verify the
 signature.
 
 --- middle


### PR DESCRIPTION
I feel like it's not so much on what the consumer should do, but more about what the sender is indicating - "I didn't sign this because I'm not expecting you to validate my signature" (or "Too Long, Didn't Send"?)